### PR TITLE
Pr05/migrate user controller oct proposal 2

### DIFF
--- a/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
+++ b/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
@@ -90,6 +90,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
     beforeEach(async () => {
       (User.findById as jest.Mock).mockResolvedValue(null);
       request.user = { id: 'nonexistent-id' };
+      request.body = minimumValidRequest;
 
       await updateSettings(request, response, next);
     });
@@ -261,7 +262,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
           });
           expect(saveUser).toHaveBeenCalledTimes(1);
         });
-        it('does not send a confirmation email to the user', () => {
+        it('sends a confirmation email to the user', () => {
           expect(mailerService.send).toHaveBeenCalledWith(
             expect.objectContaining({
               subject: 'Mock confirm your email'
@@ -293,7 +294,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
           });
           expect(saveUser).toHaveBeenCalledTimes(1);
         });
-        it('does not send a confirmation email to the user', () => {
+        it('sends a confirmation email to the user', () => {
           expect(mailerService.send).toHaveBeenCalledWith(
             expect.objectContaining({
               subject: 'Mock confirm your email'
@@ -304,14 +305,14 @@ describe('user.controller > auth management > updateSettings (email, username, p
     });
 
     describe('unhappy paths', () => {
-      describe.skip('when missing username', () => {
+      describe('when missing username', () => {
         beforeEach(async () => {
           request.setBody({ email: OLD_EMAIL });
           await updateSettings(request, response, next);
         });
 
         it('returns 401 with an "Missing username" message', () => {
-          expect(response.status).toHaveBeenCalledWith(400);
+          expect(response.status).toHaveBeenCalledWith(401);
           expect(response.json).toHaveBeenCalledWith({
             error: 'Username is required.'
           });
@@ -325,14 +326,14 @@ describe('user.controller > auth management > updateSettings (email, username, p
         });
       });
 
-      describe.skip('when missing email', () => {
+      describe('when missing email', () => {
         beforeEach(async () => {
           request.setBody({ username: OLD_USERNAME });
           await updateSettings(request, response, next);
         });
 
         it('returns 401 with an "Missing email" message', () => {
-          expect(response.status).toHaveBeenCalledWith(400);
+          expect(response.status).toHaveBeenCalledWith(401);
           expect(response.json).toHaveBeenCalledWith({
             error: 'Email is required.'
           });
@@ -346,7 +347,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
         });
       });
 
-      describe.skip('when given old username, old email, and matching current password and no new password', () => {
+      describe('when given old username, old email, and matching current password and no new password', () => {
         beforeEach(async () => {
           requestBody = {
             ...minimumValidRequest,
@@ -356,15 +357,11 @@ describe('user.controller > auth management > updateSettings (email, username, p
           await updateSettings(request, response, next);
         });
 
-        it('returns 401 with an "New password is required" message', () => {
-          expect(response.status).toHaveBeenCalledWith(400);
-          expect(response.json).toHaveBeenCalledWith({
-            error: 'New password is required.'
+        it('saves the user with the correct details once', () => {
+          expect(saveUser).toHaveBeenCalledWith(response, {
+            ...startingUser
           });
-        });
-
-        it('does not save the user with the new password', () => {
-          expect(saveUser).not.toHaveBeenCalled();
+          expect(saveUser).toHaveBeenCalledTimes(1);
         });
         it('does not send a confirmation email to the user', () => {
           expect(mailerService.send).not.toHaveBeenCalled();
@@ -374,6 +371,8 @@ describe('user.controller > auth management > updateSettings (email, username, p
       describe('when given old username, old email, and non-matching current password and a new password', () => {
         beforeEach(async () => {
           testUser.comparePassword = jest.fn().mockResolvedValue(false);
+
+          console.log('given non-matching');
 
           requestBody = {
             ...minimumValidRequest,

--- a/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
+++ b/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
@@ -240,7 +240,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
         });
       });
 
-      describe.skip('when given old username, new email, and new password with valid current password', () => {
+      describe('when given old username, new email, and new password with valid current password', () => {
         beforeEach(async () => {
           requestBody = {
             ...minimumValidRequest,
@@ -271,7 +271,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
         });
       });
 
-      describe.skip('when given new username, new email, and new password with valid current password', () => {
+      describe('when given new username, new email, and new password with valid current password', () => {
         beforeEach(async () => {
           requestBody = {
             username: NEW_USERNAME,
@@ -371,8 +371,6 @@ describe('user.controller > auth management > updateSettings (email, username, p
       describe('when given old username, old email, and non-matching current password and a new password', () => {
         beforeEach(async () => {
           testUser.comparePassword = jest.fn().mockResolvedValue(false);
-
-          console.log('given non-matching');
 
           requestBody = {
             ...minimumValidRequest,

--- a/server/controllers/user.controller/authManagement.ts
+++ b/server/controllers/user.controller/authManagement.ts
@@ -149,6 +149,16 @@ export const updateSettings: RequestHandler<
   PublicUserOrError,
   UpdateSettingsRequestBody
 > = async (req, res) => {
+  if (!req.body.username) {
+    res.status(401).json({ error: 'Username is required.' });
+    return;
+  }
+
+  if (!req.body.email) {
+    res.status(401).json({ error: 'Email is required.' });
+    return;
+  }
+
   try {
     const user = await User.findById(req.user!.id);
     if (!user) {
@@ -166,8 +176,6 @@ export const updateSettings: RequestHandler<
         res.status(401).json({ error: 'Current password is not provided.' });
         return;
       }
-    }
-    if (req.body.currentPassword) {
       const isMatch = await user.comparePassword(req.body.currentPassword);
       if (!isMatch) {
         res.status(401).json({ error: 'Current password is invalid.' });

--- a/server/controllers/user.controller/authManagement.ts
+++ b/server/controllers/user.controller/authManagement.ts
@@ -9,7 +9,8 @@ import {
   ResetPasswordInitiateRequestBody,
   ResetOrUpdatePasswordRequestParams,
   UpdatePasswordRequestBody,
-  UpdateSettingsRequestBody
+  UpdateSettingsRequestBody,
+  RenderedMailerData
 } from '../../types';
 import { mailerService } from '../../utils/mail';
 import { renderResetPassword, renderEmailConfirmation } from '../../views/mail';
@@ -165,38 +166,27 @@ export const updateSettings: RequestHandler<
       res.status(404).json({ error: 'User not found' });
       return;
     }
+
+    // Emails to send after saving
+    const emailsToSend: RenderedMailerData[] = [];
+
+    // Username (always overwrite)
     user.username = req.body.username;
 
-    if (req.body.newPassword) {
-      if (user.password === undefined) {
-        user.password = req.body.newPassword;
-        saveUser(res, user);
-      }
-      if (!req.body.currentPassword) {
-        res.status(401).json({ error: 'Current password is not provided.' });
-        return;
-      }
-      const isMatch = await user.comparePassword(req.body.currentPassword);
-      if (!isMatch) {
-        res.status(401).json({ error: 'Current password is invalid.' });
-        return;
-      }
-      user.password = req.body.newPassword!;
-      await saveUser(res, user);
-    } else if (user.email !== req.body.email) {
+    // Email change
+    if (user.email !== req.body.email) {
+      user.email = req.body.email;
+
       const EMAIL_VERIFY_TOKEN_EXPIRY_TIME = Date.now() + 3600000 * 24; // 24 hours
       user.verified = User.EmailConfirmation().Sent;
-
-      user.email = req.body.email;
 
       const token = await generateToken();
       user.verifiedToken = token;
       user.verifiedTokenExpires = EMAIL_VERIFY_TOKEN_EXPIRY_TIME;
 
-      await saveUser(res, user);
-
+      // generate email for confirming email change:
       const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
-      const mailOptions = renderEmailConfirmation({
+      const confirmEmailChange = renderEmailConfirmation({
         body: {
           domain: `${protocol}://${req.headers.host}`,
           link: `${protocol}://${req.headers.host}/verify?t=${token}`
@@ -204,9 +194,32 @@ export const updateSettings: RequestHandler<
         to: user.email
       });
 
-      await mailerService.send(mailOptions);
-    } else {
-      await saveUser(res, user);
+      emailsToSend.push(confirmEmailChange);
+    }
+
+    // Password
+    if (req.body.newPassword) {
+      if (user.password === undefined) {
+        user.password = req.body.newPassword;
+      } else if (!req.body.currentPassword) {
+        res.status(401).json({ error: 'Current password is not provided.' });
+        return;
+      } else {
+        const isMatch = await user.comparePassword(req.body.currentPassword);
+        if (!isMatch) {
+          res.status(401).json({ error: 'Current password is invalid.' });
+          return;
+        }
+        user.password = req.body.newPassword;
+      }
+    }
+
+    // Always save for simplicity
+    await saveUser(res, user);
+
+    // Send any queued emails (e.g., email verification)
+    if (emailsToSend.length > 0) {
+      await Promise.all(emailsToSend.map((email) => mailerService.send(email)));
     }
   } catch (err) {
     res.status(500).json({ error: err });


### PR DESCRIPTION
Proposing some logic changes to enable user to change both email and username at the same time, given this is what the current UI seems to allow

<img width="1130" height="826" alt="Screenshot 2025-10-10 at 15 33 03" src="https://github.com/user-attachments/assets/bbf48c5e-8177-42d0-8d12-0e8ea160f2f9" />

<img width="1130" height="845" alt="Screenshot 2025-10-10 at 15 35 12" src="https://github.com/user-attachments/assets/774a655e-8424-47fe-995e-d5a0be82d13d" />


Changes:

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
